### PR TITLE
Add skip shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Use Vim keys to navigate the menu.
 You can also use arrow keys if your keyboard has them.
 
 ### Key bindings
+* `t` toggles fast-forward transition on/off. If no subtitles are played, the player will speed up playback until the next subtitle starts. 
+* `r` toggles instant skip transitions. If no subtitles are played, the player will immediately skip until the beginning of the next subtitle.
+Note that only one transition mode can be active at a time (either fast-forward or instant skip).
+
+### Key bindings (with menu open) 
 
 * `Esc` or `q` closes the menu.
 * `t` toggles transitions.

--- a/README.md
+++ b/README.md
@@ -38,12 +38,26 @@ Use Vim keys to navigate the menu.
 
 You can also use arrow keys if your keyboard has them.
 
-### Key bindings
-* `t` toggles fast-forward transition on/off. If no subtitles are played, the player will speed up playback until the next subtitle starts. 
-* `r` toggles instant skip transitions. If no subtitles are played, the player will immediately skip until the beginning of the next subtitle.
+### Global key bindings
+
+Add the following to your `input.conf` to enable or change global key bindings:
+
+```
+t script-binding sub_transition_toggle_fast_forward
+r script-binding sub_transition_skip_immediately
+N script-binding sub_transition_menu_open
+```
+
+* <kbd>t</kbd> toggles fast-forward transition on/off.
+  If no subtitles are played,
+  the player will speed up playback until the next subtitle starts.
+* <kbd>r</kbd> toggles instant skip transitions.
+  If no subtitles are played,
+  the player will immediately skip until the beginning of the next subtitle.
+
 Note that only one transition mode can be active at a time (either fast-forward or instant skip).
 
-### Key bindings (with menu open) 
+### Key bindings (with menu open)
 
 * `Esc` or `q` closes the menu.
 * `t` toggles transitions.

--- a/main.lua
+++ b/main.lua
@@ -66,7 +66,7 @@ local menu = Menu:new { selected = 1 }
 
 menu.keybindings = {
     -- bindings
-    { key = 't', fn = menu:with_update { transitions.toggle } },
+    { key = 't', fn = menu:with_update { transitions.toggle_enabled } },
     { key = 's', fn = save_config },
     { key = 'ESC', fn = function() menu:close() end },
     { key = 'q', fn = function() menu:close() end },
@@ -143,11 +143,13 @@ local main = (function()
     local function fn()
         if not init_done then
             mpopt.read_options(config, NAME)
+            mp.add_key_binding("t", NAME .. '_transition_toggle_fast_forward', function() transitions:toggle_fast_forward() end)
+            mp.add_key_binding("r", NAME .. '_transition_skip_immediately', function() transitions:toggle_skip_immediately() end)
             mp.add_key_binding("shift+n", NAME .. '_menu_open', function() menu:open() end)
             transitions.init(config)
             hide_subs.init(config)
             if config.start_enabled then
-                transitions.toggle()
+                transitions.toggle_enabled()
             end
             if default_readahead_secs < recommended_readahead_secs then
                 mp.set_property("demuxer-readahead-secs", recommended_readahead_secs)

--- a/main.lua
+++ b/main.lua
@@ -143,9 +143,12 @@ local main = (function()
     local function fn()
         if not init_done then
             mpopt.read_options(config, NAME)
-            mp.add_key_binding("t", NAME .. '_transition_toggle_fast_forward', function() transitions:toggle_fast_forward() end)
-            mp.add_key_binding("r", NAME .. '_transition_skip_immediately', function() transitions:toggle_skip_immediately() end)
-            mp.add_key_binding("shift+n", NAME .. '_menu_open', function() menu:open() end)
+
+            -- Global key bindings
+            mp.add_key_binding(nil, string.format("%s_toggle_fast_forward", NAME), function() transitions:toggle_fast_forward() end)
+            mp.add_key_binding(nil, string.format("%s_skip_immediately", NAME), function() transitions:toggle_skip_immediately() end)
+            mp.add_key_binding("shift+n", string.format("%s_menu_open", NAME), function() menu:open() end)
+
             transitions.init(config)
             hide_subs.init(config)
             if config.start_enabled then

--- a/transitions.lua
+++ b/transitions.lua
@@ -121,8 +121,9 @@ local function check_sub()
     end
 end
 
-local function toggle()
-    if not self.enabled then
+local function toggle_enabled(val)
+    self.enabled = val or not self.enabled
+    if self.enabled then
         mp.observe_property("sub-end", "number", check_sub)
         mp.observe_property("sub-text", "string", check_sub)
         h.notify { message = "Transitions enabled.", osd = self.config.notifications, }
@@ -131,10 +132,29 @@ local function toggle()
         reset_transition()
         h.notify { message = "Transitions disabled.", osd = self.config.notifications, }
     end
-    self.enabled = not self.enabled
 end
+
+local function toggle_fast_forward()
+    if not (self.enabled and self.config.skip_immediately) then
+        toggle_enabled()
+    end
+    self.config.skip_immediately = false
+end
+
 local function status()
     return self.enabled and 'enabled' or 'disabled'
+end
+
+local function toggle_skip_immediately()
+    local is_enabled = not self.config.skip_immediately
+    toggle_enabled(is_enabled)
+    self.config.skip_immediately = is_enabled
+
+    if is_enabled then
+        h.notify { message = "Transition skip enabled.", osd = self.config.skip_immediately, }
+    else
+        h.notify { message = "Transition skip disabled.", osd = self.config.skip_immediately, }
+    end
 end
 
 local function init(config)
@@ -143,7 +163,9 @@ end
 
 return {
     init = init,
-    toggle = toggle,
+    toggle_enabled = toggle_enabled,
+    toggle_fast_forward = toggle_fast_forward,
+    toggle_skip_immediately = toggle_skip_immediately,
     status = status,
     reset = reset_transition,
     check_sub = check_sub,


### PR DESCRIPTION
I wanted more control over the video speed, so I've added shortcuts (which don't require menu being opened). The shortcuts work as follows: 
- `t` and `r` toggle their respective functions on/off (fast forward and skip immediately) 
- only one can be active at a time.

`t` invoked from the menu and user's settings still work as before - they will use the user's `skip_immediately` value to either FF or skip immediately. `t` and `r` will bypass that and always invoke FF and immediate skip, respectively.